### PR TITLE
Add modem sensors and polling of modem state

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ This component is not official, developed, supported or endorsed by Compal.
  
 Add a configuration to your `configuration.yaml` file:
 ``` yaml
-switch:
-  - platform: compal_wifi
-    host: 192.168.0.1
+compal_wifi:
+    host: 192.168.1.1
     password: YOUR_PASSWORD
 ```
 
@@ -39,6 +38,7 @@ Key | Type | Required | Description
 `password` | `string` | `True` | The password for your modems administration account.
 `guest` | `bool` | `False` | Enable guest network when switching ON WIFI. 
 `pause` | `int` | `False` | Number of seconds to wait between modem changes (default 60s).
+`polling_interval` | `int` | `False` | Number of seconds to poll modem state (default 3600s - 1h).
 
 
 ## Platforms
@@ -62,6 +62,17 @@ Name | Values | Description
 ---- | ------ | -----------
 `state` | `on` or `off` | Switch state.
 `switch_progress` | `on`, `off` or `error` | Whether a swich change is in progress or not or `error` if the last switch operation was faulty.
+
+### Sensor
+The componet offers various sensors:
+
+Entity | Description
+---- | -----------
+switch.compal.wifi.modem.model | Modem model
+switch.compal.wifi.modem.hardware Version | Hardware version
+switch.compal.wifi.modem.software Version | Software version
+switch.compal.wifi.modem.operator | Modem operator
+switch.compal.wifi.modem.uptime | Modem uptime
 
 ## Integration
 The integration with the compal modem is done using [compal-wifi-switch](https://github.com/frimtec/compal-wifi-switch).  

--- a/custom_components/compal_wifi/__init__.py
+++ b/custom_components/compal_wifi/__init__.py
@@ -1,1 +1,58 @@
 """The Compal WiFi component."""
+import threading
+from datetime import datetime
+
+from compal_wifi_switch import Commands
+
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+
+DOMAIN = "compal_wifi"
+
+CONF_PAUSE = "pause"
+DEFAULT_PAUSE = 60
+
+CONF_GUEST = "guest"
+DEFAULT_GUEST = False
+
+CONF_POLLING_INTERVAL = "polling_interval"
+DEFAULT_POLLING_INTERVAL = 60 * 60
+
+ATTR_RADIO = "radio"
+DEFAULT_RADIO = "all"
+
+
+def setup(hass, config):
+    """Your controller/hub specific code."""
+
+    domain_config = config[DOMAIN]
+    states = Commands.status(domain_config[CONF_HOST], domain_config[CONF_PASSWORD])
+
+    compal_config = CompalConfig(
+        domain_config[CONF_HOST],
+        domain_config[CONF_PASSWORD],
+        domain_config.get(CONF_PAUSE, DEFAULT_PAUSE),
+        domain_config.get(CONF_GUEST, DEFAULT_GUEST),
+        domain_config.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL),
+        states,
+    )
+
+    # Data that you want to share with your platforms
+    hass.data[DOMAIN] = compal_config
+
+    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    hass.helpers.discovery.load_platform("switch", DOMAIN, {}, config)
+    return True
+
+
+class CompalConfig:
+    def __init__(
+        self, host, password, pause, guest, polling_interval, current_modem_state
+    ):
+        self.host = host
+        self.password = password
+        self.pause = pause
+        self.guest = guest
+        self.polling_interval = polling_interval
+        self.current_modem_state = current_modem_state
+        self.last_update = datetime.now()
+        self.semaphore = threading.Semaphore()

--- a/custom_components/compal_wifi/manifest.json
+++ b/custom_components/compal_wifi/manifest.json
@@ -10,6 +10,6 @@
   "codeowners": [
     "@frimtec"
   ],
-  "iot_class": "assumed_state",
+  "iot_class": "local_polling",
   "version": "0.0.0"
 }

--- a/custom_components/compal_wifi/sensor.py
+++ b/custom_components/compal_wifi/sensor.py
@@ -38,15 +38,31 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     compal_config = hass.data[DOMAIN]
     add_entities(
         [
-            ModemSensor("Compal Wifi Modem Model", "model", compal_config),
             ModemSensor(
-                "Compal Wifi Modem Hardware Version", "hw_version", compal_config
+                "Compal Wifi Modem Model",
+                compal_config,
+                lambda modem: modem["model"],
             ),
             ModemSensor(
-                "Compal Wifi Modem Software Version", "sw_version", compal_config
+                "Compal Wifi Modem Hardware Version",
+                compal_config,
+                lambda modem: modem["hw_version"],
             ),
-            ModemSensor("Compal Wifi Modem Operator", "operator_id", compal_config),
-            ModemSensor("Compal Wifi Modem Uptime", "uptime", compal_config),
+            ModemSensor(
+                "Compal Wifi Modem Software Version",
+                compal_config,
+                lambda modem: modem["sw_version"].replace(modem["model"] + "-", "", 1),
+            ),
+            ModemSensor(
+                "Compal Wifi Modem Operator",
+                compal_config,
+                lambda modem: modem["operator_id"],
+            ),
+            ModemSensor(
+                "Compal Wifi Modem Uptime",
+                compal_config,
+                lambda modem: modem["uptime"].split(":", 1)[0],
+            ),
         ]
     )
 
@@ -54,12 +70,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ModemSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, name, attribute, compal_config):
+    def __init__(self, name, compal_config, attribute_accessor):
         """Initialize the sensor."""
         self._name = name
-        self._attribute = attribute
         self._compal_config = compal_config
-        self._state = compal_config.current_modem_state["modem"][attribute]
+        self._attribute_accessor = attribute_accessor
+        self._state = attribute_accessor(compal_config.current_modem_state["modem"])
 
     @property
     def name(self):
@@ -80,4 +96,6 @@ class ModemSensor(Entity):
         ):
             modem_status(self._compal_config)
 
-        self._state = self._compal_config.current_modem_state["modem"][self._attribute]
+        self._state = self._attribute_accessor(
+            self._compal_config.current_modem_state["modem"]
+        )

--- a/custom_components/compal_wifi/sensor.py
+++ b/custom_components/compal_wifi/sensor.py
@@ -1,0 +1,83 @@
+"""Platform for sensor integration."""
+import threading
+from datetime import datetime
+from datetime import timedelta
+
+from compal_wifi_switch import Commands
+
+from homeassistant.helpers.entity import Entity
+from . import DOMAIN
+
+
+def modem_status(compal_config):
+    def modem_status_blocking():
+        compal_config.semaphore.acquire()
+        try:
+            compal_config.current_modem_state = Commands.status(
+                compal_config.host, compal_config.password
+            )
+            compal_config.last_update = datetime.now()
+        except:
+            compal_config.last_update = compal_config.last_update - timedelta(
+                seconds=compal_config.polling_interval
+            )
+        finally:
+            compal_config.semaphore.release()
+
+    compal_config.last_update = datetime.now()
+    threading.Thread(
+        target=modem_status_blocking,
+    ).start()
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    # We only want this platform to be set up via discovery.
+    if discovery_info is None:
+        return
+    compal_config = hass.data[DOMAIN]
+    add_entities(
+        [
+            ModemSensor("Compal Wifi Modem Model", "model", compal_config),
+            ModemSensor(
+                "Compal Wifi Modem Hardware Version", "hw_version", compal_config
+            ),
+            ModemSensor(
+                "Compal Wifi Modem Software Version", "sw_version", compal_config
+            ),
+            ModemSensor("Compal Wifi Modem Operator", "operator_id", compal_config),
+            ModemSensor("Compal Wifi Modem Uptime", "uptime", compal_config),
+        ]
+    )
+
+
+class ModemSensor(Entity):
+    """Representation of a sensor."""
+
+    def __init__(self, name, attribute, compal_config):
+        """Initialize the sensor."""
+        self._name = name
+        self._attribute = attribute
+        self._compal_config = compal_config
+        self._state = compal_config.current_modem_state["modem"][attribute]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Fetch new state data for the sensor.
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        if (datetime.now() - self._compal_config.last_update) > timedelta(
+            seconds=self._compal_config.polling_interval
+        ):
+            modem_status(self._compal_config)
+
+        self._state = self._compal_config.current_modem_state["modem"][self._attribute]


### PR DESCRIPTION
### Features
* Various new sensors
* Polling for modem state

### Breaking Changes

#### Configuration moved from switch platform to domain _compal_wifi_.
The configuration moved from the switch platform to the domain _compal_wifi_.

Old configuration (until 1.1.x): 
```
switch:
  - platform: compal_wifi
    host: 192.168.0.1
    password: YOUR_PASSWORD
```
New configuration (since 1.2.0):
```
compal_wifi:
    host: 192.168.1.1
    password: YOUR_PASSWORD
```
